### PR TITLE
Fix license arg to setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author = "David Eyk",
     author_email = "deyk@crossway.org",
     url = "http://github.com/Crossway/antimarkdown/",
-    license = 'BSD',
+    license = 'MIT',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
The actual LICENSE in the repo uses the MIT wording. cf. https://opensource.org/licenses/MIT

Closes #12